### PR TITLE
Rename typo in Header.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dietician",
+  "name": "dietitian",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -25,7 +25,7 @@ const Header = (props) => {
         <div className={classes.container}>
           <Link to="/">
             <Typography variant="h6" className={classes.title}>
-              <span>Dietician </span>
+              <span>Dietitian </span>
               <span role='img' aria-label='avocado'>🥑</span>
             </Typography>
           </Link>


### PR DESCRIPTION
Just renaming the typo in the website´s header. Learn to spell it right, Matt!